### PR TITLE
Prevent app crash on KitKat

### DIFF
--- a/app/src/main/java/org/cuberite/android/SettingsActivity.java
+++ b/app/src/main/java/org/cuberite/android/SettingsActivity.java
@@ -201,7 +201,7 @@ public class SettingsActivity extends AppCompatActivity {
                 } else {
                     try {
                         Ini ini = new Ini(settingsFile);
-                        int enabled = ini.get("Authentication", "Authenticate", int.class);
+                        int enabled = Integer.parseInt(ini.get("Authentication", "Authenticate"));
                         int newenabled = enabled ^ 1; // XOR: 0 ^ 1 => 1, 1 ^ 1 => 0
                         ini.put("Authentication", "Authenticate", newenabled);
                         ini.store(settingsFile);


### PR DESCRIPTION
Prevent the app from crashing when toggling authentication on Android KitKat.