### PR TITLE
Stop service before updating button

### DIFF
--- a/app/src/main/java/org/cuberite/android/services/CuberiteService.java
+++ b/app/src/main/java/org/cuberite/android/services/CuberiteService.java
@@ -241,7 +241,7 @@ public class CuberiteService extends IntentService {
         }
 
         // Update button state
-        LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent("CuberiteService.callback"));
         stopSelf();
+        LocalBroadcastManager.getInstance(this).sendBroadcast(new Intent("CuberiteService.callback"));
     }
 }


### PR DESCRIPTION
Fixes a rare issue where the button would be set to the running state after stopping the server.