### PR TITLE
SHA1 error fixes

### DIFF
--- a/app/src/main/java/org/cuberite/android/helpers/ProgressReceiver.java
+++ b/app/src/main/java/org/cuberite/android/helpers/ProgressReceiver.java
@@ -42,6 +42,7 @@ public class ProgressReceiver extends ResultReceiver {
                 progressDialog = new ProgressDialog(cont);
                 progressDialog.setTitle(title);
                 progressDialog.setProgressStyle(ProgressDialog.STYLE_HORIZONTAL);
+                progressDialog.setIndeterminate(true);
                 progressDialog.show();
 
                 progressDialog.setCanceledOnTouchOutside(false);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -13,9 +13,9 @@
     <string name="do_open_settings">Einstellungen</string>
 
     <string name="status_downloading_cuberite">Lade Cuberite herunter…</string>
+    <string name="status_shasum_error">Integritätsfehler</string>
     <string name="status_delete_file_error">Fehler: konnte Datei nicht löschen</string>
     <string name="status_permissions_needed">Berechtigung benötigt</string>
-    <string name="status_shasum_error">Integritätsfehler</string>
     <string name="status_missing_filemanager">Kein Dateimanager gefunden: bitte einen zu Installieren</string>
 
     <string name="notification_cuberite_running">Cuberite läuft!</string>
@@ -26,7 +26,6 @@
     <string name="inputLine_hint">Befehl eingeben…</string>
 
     <string name="message_externalstorage_permission">Normalerweise versucht Cuberite die Welt auf der SDCard zu speichern, diese kann dann von anderen Apps geöffnet werden. Wenn sie Cuberite nicht die Rechte geben wollen, können sie \"nicht nochmal fragen\" wählen. Cuberite wird dann die Daten intern speichern.</string>
-    <string name="message_shasum_not_matching">Die SHA-1 Summen stimmen nicht überein. Das kann bedeuten, dass jemand versucht sie zu spoofen, es kann sich aber auch nur um einen Fehler handeln. Versuchen sie es erneut. Sollte der Fehler weiter auftreten können Sie Cuberite über die Einstellungen manuell installieren</string>
 
     <string name="title_activity_settings">@string/do_open_settings</string>
 

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -13,9 +13,9 @@
     <string name="do_open_settings">Instellingen</string>
 
     <string name="status_downloading_cuberite">Downloaden Cuberite…</string>
+    <string name="status_shasum_error">SHA-1 validatie fout</string>
     <string name="status_delete_file_error">Er ging iets fout: kon het bestand niet verwijderen</string>
     <string name="status_permissions_needed">Toestemming nodig</string>
-    <string name="status_shasum_error">SHA-1 validatie fout</string>
     <string name="status_missing_filemanager">Geen bestandsbeheerder gevonden: installeer er a.u.b een</string>
 
     <string name="notification_cuberite_running">Cuberite draait!</string>
@@ -26,7 +26,6 @@
     <string name="inputLine_hint">Voer commando\'s in…</string>
 
     <string name="message_externalstorage_permission">Cuberite bewaart de werelden standaard op externe opslagmedia die lees- en schrijfbaar zijn door iedere app. Hiervoor moet u Cuberite toestaan om te schrijven naar het externe medium. Als u de nodige toestemming niet wilt geven, selecteer de \"vraag niet opnieuw\" optie en Cuberite zal de app zijn privé opslag gebruiken.</string>
-    <string name="message_shasum_not_matching">SHA-1 sommen komen zijn niet gelijk. Dit kan gewoon een download fout zijn of iemand probeert uw download te vervalsen. Probeer a.u.b opnieuw, als de fout opnieuw gebeurt kan u de controle afzetten door Cuberite te installeren via de Instellingen.</string>
 
     <string name="title_activity_settings">Instellingen</string>
 

--- a/app/src/main/res/values-pt/strings.xml
+++ b/app/src/main/res/values-pt/strings.xml
@@ -13,9 +13,9 @@
     <string name="do_open_settings">Configurações</string>
 
     <string name="status_downloading_cuberite">Transferindo o Cuberite…</string>
+    <string name="status_shasum_error">Erro ao executar a validação SHA-1</string>
     <string name="status_delete_file_error">Algo deu errado: Não foi possível apagar o arquivo</string>
     <string name="status_permissions_needed">Permissões necessarias</string>
-    <string name="status_shasum_error">Erro ao executar a validação SHA-1</string>
     <string name="status_missing_filemanager">Nenhum explorador de arquivos encontrado: Por favor instale um</string>
 
     <string name="notification_cuberite_running">Cuberite está rodando!</string>
@@ -26,7 +26,6 @@
     <string name="inputLine_hint">Insira comandos…</string>
 
     <string name="message_externalstorage_permission">Cuberite armazena seus mundos por padrão no armazenamento externo, que é acessível por qualquer aplicativo. Para isso, você precisa permitir que o Cuberite escreva no armazenamento externo. Se você não quiser dar a permissão necessária para isso, por favor selecione a opção \"Não perguntar novamente\". Assim, o Cuberite irá usar o armazenamento privado do aplicativo</string>
-    <string name="message_shasum_not_matching">As somas SHA-1 não batem. Isso pode significar que alguém está tentanto te enganar ou pode simplesmente ser um erro na transferência. Tente baixar novamente, caso o erro persista você pode desabilitar essa verificação instalando Cuberite através das Configurações</string>
 
     <string name="title_activity_settings">Configurações</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -17,6 +17,7 @@
     <string name="do_open_settings">Settings</string>
 
     <string name="status_downloading_cuberite">Downloading Cuberite…</string>
+    <string name="status_shasum_error">SHA-1 validation error</string>
     <string name="status_installing_cuberite">Installing Cuberite…</string>
     <string name="status_install_success">Successfully installed Cuberite!</string>
     <string name="status_unzip_error">Failed to unzip the server files</string>
@@ -24,7 +25,6 @@
     <string name="status_delete_file_error">Something went wrong: Couldn\'t delete file</string>
     <string name="status_failed_start">Cuberite failed to start. Ensure that your binary has the following ABI: %1$s</string>
     <string name="status_permissions_needed">Permissions needed</string>
-    <string name="status_shasum_error">SHA-1 validation error</string>
     <string name="status_missing_filemanager">No filemanager found: Please install one</string>
 
     <string name="notification_cuberite_running">Cuberite is running!</string>
@@ -35,7 +35,6 @@
     <string name="inputLine_hint">Enter commands…</string>
 
     <string name="message_externalstorage_permission">Cuberite stores its worlds on the external storage by default, which is readable and writable by any app. For this, you need to allow Cuberite to write to the external storage. If you don\'t want to give the necessary permission, please select the \"Deny\" option and Cuberite will use the app\'s private storage.</string>
-    <string name="message_shasum_not_matching">SHA-1 sums don\'t match. This may indicate an attempt to spoof you, or just a download error. Please try downloading Cuberite again, and if the error persists, you may bypass the check by installing Cuberite via the settings.</string>
 
     <string name="title_activity_settings">Settings</string>
 


### PR DESCRIPTION
- Dialog can't be displayed directly from a service, use existing snackbar system instead
- Set connection timeout
- Retry download once if verification failed. Don't proceed if failed twice. 